### PR TITLE
Add fzfcmd option

### DIFF
--- a/fzfinder.lua
+++ b/fzfinder.lua
@@ -1,18 +1,22 @@
 VERSION = "0.1.0"
 
-local micro = import("micro")
+local micro  = import("micro")
 local config = import("micro/config")
 local buffer = import("micro/buffer")
-local shell = import("micro/shell")
+local shell  = import("micro/shell")
 
 local fzfarg =  config.GetGlobalOption("fzfarg")
+local fzfcmd =  config.GetGlobalOption("fzfcmd")
 
 function fzfinder(bp)
   if fzfarg == nil then
-    fzfarg = "";
+     fzfarg = "";
+  end
+  if fzfcmd == nil then
+     fzfcmd = "fzf";
   end
 
-  local output, err = shell.RunInteractiveShell("fzf "..fzfarg, false, true)
+  local output, err = shell.RunInteractiveShell("sh -c '"..fzfcmd.." "..fzfarg.."'", false, true)
   if err ~= nil then
     micro.InfoBar():Error(err)
   else

--- a/fzfinder.lua
+++ b/fzfinder.lua
@@ -14,6 +14,8 @@ function fzfinder(bp)
   end
   if fzfcmd == nil then
      fzfcmd = "fzf";
+  else
+     fzfcmd = fzfcmd.." | fzf";
   end
 
   local output, err = shell.RunInteractiveShell("sh -c '"..fzfcmd.." "..fzfarg.."'", false, true)


### PR DESCRIPTION
It use sh -c to be able the pipe sh syntax.

It runs by default `sh -c 'fzf fzfargs'` and if we set fzfcmd `sh -c 'fzfcmd | fzf fzfargs'`.