### PR TITLE
no error is esc fzf

### DIFF
--- a/fzfinder.lua
+++ b/fzfinder.lua
@@ -13,9 +13,7 @@ function fzfinder(bp)
   end
 
   local output, err = shell.RunInteractiveShell("fzf "..fzfarg, false, true)
-  if err ~= nil then
-    micro.InfoBar():Error(err)
-  else
+  if err == nil then
     fzfOutput(output, {bp})
   end
 


### PR DESCRIPTION
Why sending an error if we just escape fzf with esc because we just want to cancel our move? It disturb users, making them feel a real error has occured. If we want to catch real errors from the fzf process (but it is necessary? Fzf is reliable...) we can use another way, like capturing the return code of the fzf process I guess...