### PR TITLE
fzf base dir from current buffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,12 @@ micro -plugin install fzfinder
 
 Fzf parameters can be set by means of `options` in the file `settings.json`:
 
+NOTE: `bat` can be replaced with `cat`.
+
 ~~~json
-"fzfarg": "--layout=reverse  --preview 'cat {}' --color=bw",
+"fzfarg": "--preview 'bat -f -p {}'",
+"fzfcmd": "/usr/bin/fzf",
+"fzfopen": "newtab",
 ~~~
 
 We can also configure launch through `hot keys` in the file  `bindings.json`:

--- a/fzfinder.lua
+++ b/fzfinder.lua
@@ -4,6 +4,7 @@ local micro = import("micro")
 local config = import("micro/config")
 local buffer = import("micro/buffer")
 local shell = import("micro/shell")
+local filepath = import("path/filepath")
 
 local fzfArg =  config.GetGlobalOption("fzfarg")
 local fzfCmd =  config.GetGlobalOption("fzfcmd")
@@ -18,13 +19,19 @@ function fzfinder(bp)
      fzfCmd = "fzf";
   end
 
+  abspath = filepath.Dir(bp.buf.AbsPath)
+  bp:CdCmd({"/tmp"})
+
   if fzfOpen == nil then
     fzfOpen = "thispane"
   elseif fzfOpen == "hsplit" or fzfOpen == "vsplit" or fzfOpen == "newtab" then
     fzfArg = "-m "..fzfArg
   end
-  
+
   local output, err = shell.RunInteractiveShell(fzfCmd.." "..fzfArg, false, true)
+
+  bp:CdCmd({abspath})
+
   if err == nil then
     fzfOutput(output, {bp})
   end

--- a/fzfinder.lua
+++ b/fzfinder.lua
@@ -18,9 +18,17 @@ function fzfinder(bp)
   if fzfCmd == nil then
      fzfCmd = "fzf";
   end
+  rootdir = string.gsub(bp.buf.AbsPath, bp.buf.Path, "")
+  relative = filepath.Dir(bp.buf.Path)
+  toto = rootdir.." | "..relative
 
-  abspath = filepath.Dir(bp.buf.AbsPath)
-  bp:CdCmd({"/tmp"})
+  -- os.Chdir(relative)
+  -- if string.find(abspath, "usr") then
+      -- toto = "/tmp"
+   -- else
+      -- toto =  "/usr/local/bin"
+   -- end
+  bp:CdCmd({relative})
 
   if fzfOpen == nil then
     fzfOpen = "thispane"
@@ -30,11 +38,13 @@ function fzfinder(bp)
 
   local output, err = shell.RunInteractiveShell(fzfCmd.." "..fzfArg, false, true)
 
-  bp:CdCmd({abspath})
+  -- os.Chdir(abspath)
 
   if err == nil then
     fzfOutput(output, {bp})
   end
+
+  micro.InfoBar():Error(toto)
 end
 
 function fzfOutput(output, args)

--- a/fzfinder.lua
+++ b/fzfinder.lua
@@ -9,6 +9,7 @@ local filepath = import("path/filepath")
 local fzfArg =  config.GetGlobalOption("fzfarg")
 local fzfCmd =  config.GetGlobalOption("fzfcmd")
 local fzfOpen = config.GetGlobalOption("fzfopen")
+local fzfPath = config.GetGlobalOption("fzfpath")
 
 function fzfinder(bp)
   if fzfArg == nil then
@@ -18,17 +19,11 @@ function fzfinder(bp)
   if fzfCmd == nil then
      fzfCmd = "fzf";
   end
-  rootdir = string.gsub(bp.buf.AbsPath, bp.buf.Path, "")
-  relative = filepath.Dir(bp.buf.Path)
-  toto = rootdir.." | "..relative
 
-  -- os.Chdir(relative)
-  -- if string.find(abspath, "usr") then
-      -- toto = "/tmp"
-   -- else
-      -- toto =  "/usr/local/bin"
-   -- end
-  bp:CdCmd({relative})
+  if fzfPath == "relative" then
+    currentdir = filepath.Dir(bp.buf.Path)
+    bp:CdCmd({currentdir})
+  end
 
   if fzfOpen == nil then
     fzfOpen = "thispane"
@@ -38,13 +33,9 @@ function fzfinder(bp)
 
   local output, err = shell.RunInteractiveShell(fzfCmd.." "..fzfArg, false, true)
 
-  -- os.Chdir(abspath)
-
   if err == nil then
     fzfOutput(output, {bp})
   end
-
-  micro.InfoBar():Error(toto)
 end
 
 function fzfOutput(output, args)


### PR DESCRIPTION
The syntax I used here is completely diffrent from the syntax of my other pull request "add fzfcmd option". If we implement both, we have to rewrite both to make them compatible.

I propose the following struture:
 - always use fzf from a pipe of a command (by default `find {} -mindepth 1 | fzf fzfargs`)
 - where {} will be the base directory, by default the working directory (I suppose we can grab it easily with micro builtin pwd)
    or the relative directory if the option is set
- the fzfcmd string would be just an alternative command like "fd {} -t f" where {} will be replaced by fzfinder

OR
Maybe, the code is so small than it is easy for people to hack it, so we don't really need to add the "fzfcmd" option to write a full command, and just we can add an option "fzffd" : true if the user wants to use fd, false by default to use find. I mean, there is no really alternative to fd or find, just maybe ls but who wants to use it instead?

Tell me what you think of all that...
 